### PR TITLE
Update to use SchemeCode rather than standard

### DIFF
--- a/app/parse-siti-payment-file/payment-request.js
+++ b/app/parse-siti-payment-file/payment-request.js
@@ -19,12 +19,12 @@ const invoiceToPaymentRequest = (invoiceHeaders) => {
 }
 
 const invoiceLineToPaymentRequest = (invoiceLines) => {
-  return invoiceLines.map(invoiceline => ({
-    standardCode: invoiceline.schemeCode.toString(),
-    accountCode: invoiceline.msdaxAccountCode,
-    fundCode: invoiceline.fund,
-    description: invoiceline.lineDescription,
-    value: invoiceline.value
+  return invoiceLines.map(invoiceLine => ({
+    schemeCode: invoiceLine.schemeCode.toString(),
+    accountCode: invoiceLine.msdaxAccountCode,
+    fundCode: invoiceLine.fund,
+    description: invoiceLine.lineDescription,
+    value: invoiceLine.value
   })
   )
 }

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -27,8 +27,6 @@ services:
     command: "azurite-blob --loose --blobHost 0.0.0.0"
     volumes:
       - azurite_data:/data
-    ports:
-      - "10000:10000"
 
 volumes:
   azurite_data:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-batch-processor",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "FFC Payment Batch Processor",
   "homepage": "https://github.com/DEFRA/ffc-pay-batch-processor",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-batch-processor",
-  "version": "1.12.0"
+  "version": "1.12.0",
   "description": "FFC Payment Batch Processor",
   "homepage": "https://github.com/DEFRA/ffc-pay-batch-processor",
   "main": "app/index.js",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFI-1425

Enrichment service will pass on any provided scheme codes rather than map them from standard.  So process can be simplified for Siti Agri by just setting the scheme code the `schemeCode` property.